### PR TITLE
add setNativesPath()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.maxhenkel.opus4j</groupId>
     <artifactId>opus4j</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
 
     <name>Opus Wrapper for Java</name>
     <url>https://maxhenkel.de</url>

--- a/src/main/java/de/maxhenkel/opus4j/LibraryLoader.java
+++ b/src/main/java/de/maxhenkel/opus4j/LibraryLoader.java
@@ -5,7 +5,7 @@ import com.sun.jna.Platform;
 class LibraryLoader {
     private static String nativesPath = "";
 
-    public static String setNativesPath(String path) {
+    public static void setNativesPath(String path) {
         nativesPath = path;
     }
 

--- a/src/main/java/de/maxhenkel/opus4j/LibraryLoader.java
+++ b/src/main/java/de/maxhenkel/opus4j/LibraryLoader.java
@@ -3,15 +3,15 @@ package de.maxhenkel.opus4j;
 import com.sun.jna.Platform;
 
 class LibraryLoader {
-    private static String nativesPath = "";
-
-    public static void setNativesPath(String path) {
-        nativesPath = path;
-    }
 
     public static String getPath() {
         String platform = Platform.RESOURCE_PREFIX;
-        return String.format("%s/natives/%s/libopus.%s", nativesPath, platform, getExtension(platform));
+        return String.format("/natives/%s/libopus.%s", platform, getExtension(platform));
+    }
+
+    public static String getPath(String nativesDir) {
+        String platform = Platform.RESOURCE_PREFIX;
+        return String.format("%s/%s/libopus.%s", nativesDir, platform, getExtension(platform));
     }
 
     private static String getExtension(String platform) {

--- a/src/main/java/de/maxhenkel/opus4j/LibraryLoader.java
+++ b/src/main/java/de/maxhenkel/opus4j/LibraryLoader.java
@@ -3,10 +3,15 @@ package de.maxhenkel.opus4j;
 import com.sun.jna.Platform;
 
 class LibraryLoader {
+    private static String nativesPath = "";
+
+    public static String setNativesPath(String path) {
+        nativesPath = path;
+    }
 
     public static String getPath() {
         String platform = Platform.RESOURCE_PREFIX;
-        return String.format("/natives/%s/libopus.%s", platform, getExtension(platform));
+        return String.format("%s/natives/%s/libopus.%s", nativesPath, platform, getExtension(platform));
     }
 
     private static String getExtension(String platform) {

--- a/src/main/java/de/maxhenkel/opus4j/Opus.java
+++ b/src/main/java/de/maxhenkel/opus4j/Opus.java
@@ -13,7 +13,26 @@ import java.nio.ShortBuffer;
 
 public interface Opus extends Library {
 
-    Opus INSTANCE = Native.load(NativeLibrary.getInstance(LibraryLoader.getPath()).getFile().getAbsolutePath(), Opus.class);
+    /**
+     * Creates a new Opus instance.
+     * @param path path to natives
+     * @return an instance of Opus
+     */
+    static Opus createInstance(String path) {
+        return Native.load(LibraryLoader.getPath(path), Opus.class);
+    }
+
+    /**
+     * Creates a new Opus instance.
+     * This is a shortcut for {@link #createInstance(String)} with the default path.
+     * @return an instance of Opus
+     */
+    static Opus createInstance() {
+        return Native.load(NativeLibrary.getInstance(LibraryLoader.getPath()).getFile().getAbsolutePath(), Opus.class);
+    }
+
+    @Deprecated
+    Opus INSTANCE = null;
 
     public static final int OPUS_GET_LSB_DEPTH_REQUEST = 4037;
     public static final int OPUS_GET_APPLICATION_REQUEST = 4001;


### PR DESCRIPTION
This is in case the natives folder are stored somewhere else 

For Example:  
In spigot this library errors out because it looks in the resources spigot.jar file, so a spigot plugin could instead save the resource folder to it's plugin data folder and then sets the path to that folder then the plugin can access the Opus.INSTANCE just fine

Note: I created this pr using the GitHub web editor so I'm not sure if this would compile correctly or work as intended.